### PR TITLE
remove \r\n from process output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ before_script:
   - emulator -avd test -no-skin -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+  - adb get-devpath 
+  - adb get-state
 
 script:
   - git clone https://github.com/michalkielan/AndroidDummyApp.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ before_script:
   - emulator -avd test -no-skin -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-  - adb get-state
 
 script:
   - git clone https://github.com/michalkielan/AndroidDummyApp.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ before_script:
   - emulator -avd test -no-skin -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-  - adb get-devpath 
   - adb get-state
 
 script:

--- a/simpleadb.py
+++ b/simpleadb.py
@@ -22,7 +22,8 @@ class AdbDevice(object):
         args,
     ])
     output = adbprocess.check_output(cmd)
-    return output.decode(get_encoding_format())
+    decoded = output.decode(get_encoding_format())
+    return decoded.rstrip("\n\r")
 
   def get_id(self):
     return self.__id

--- a/test_simpleadb.py
+++ b/test_simpleadb.py
@@ -60,6 +60,11 @@ class AdbServerTest(unittest.TestCase):
     res = device.setprop("dummy_prop", "true")
     self.assertEqual(res, 0)
 
+  def test_get_state(self):
+    device = simpleadb.AdbDevice(TEST_DEVICE_ID)
+    state = device.get_state()
+    self.assertEqual(state, 'device')
+
   def test_available(self):
     device = simpleadb.AdbDevice(TEST_DEVICE_ID)
     self.assertTrue(device.is_available())


### PR DESCRIPTION
fix for
```
test_simpleadb.py::AdbServerTest::test_get_state FAILED                      [100%]
      device = simpleadb.AdbDevice(TEST_DEVICE_ID)
      state = device.get_state()
>     self.assertEqual(state, 'device')
E     AssertionError: 'device\n' != 'device'
```