### PR TITLE
wait for done when adb restart

### DIFF
--- a/simpleadb.py
+++ b/simpleadb.py
@@ -4,6 +4,9 @@ import adbprefixes
 def get_encoding_format():
   return 'utf-8'
 
+def get_adb_restart_timeout_sec():
+  return 5
+
 # pylint: disable=too-many-public-methods
 class AdbDevice(object):
   def __init__(self, device_id):
@@ -56,13 +59,25 @@ class AdbDevice(object):
     cmd = adbprefixes.get_reboot()
     self.__check_call(cmd)
 
-  def root(self):
+  def root(
+      self,
+      timeout_sec=get_adb_restart_timeout_sec()
+    ):
     cmd = adbprefixes.get_root()
-    return self.__check_call(cmd)
+    res = self.__check_call(cmd)
+    if res == 0:
+      return self.wait_for_device(timeout=timeout_sec)
+    return res
 
-  def unroot(self):
+  def unroot(
+      self,
+      timeout_sec=get_adb_restart_timeout_sec()
+    ):
     cmd = adbprefixes.get_unroot()
-    return self.__check_call(cmd)
+    res = self.__check_call(cmd)
+    if res == 0:
+      return self.wait_for_device(timeout=timeout_sec)
+    return res
 
   def usb(self):
     cmd = adbprefixes.get_usb()

--- a/simpleadb.py
+++ b/simpleadb.py
@@ -61,8 +61,7 @@ class AdbDevice(object):
 
   def root(
       self,
-      timeout_sec=get_adb_restart_timeout_sec()
-    ):
+      timeout_sec=get_adb_restart_timeout_sec()):
     cmd = adbprefixes.get_root()
     res = self.__check_call(cmd)
     if res == 0:
@@ -71,8 +70,7 @@ class AdbDevice(object):
 
   def unroot(
       self,
-      timeout_sec=get_adb_restart_timeout_sec()
-    ):
+      timeout_sec=get_adb_restart_timeout_sec()):
     cmd = adbprefixes.get_unroot()
     res = self.__check_call(cmd)
     if res == 0:

--- a/test_simpleadb.py
+++ b/test_simpleadb.py
@@ -35,7 +35,6 @@ class AdbServerTest(unittest.TestCase):
     device = simpleadb.AdbDevice(TEST_DEVICE_ID)
     res = device.root()
     self.assertEqual(res, 0)
-    os.system('adb wait-for-device shell input keyevent 82')
 
   def test_get_id(self):
     device = simpleadb.AdbDevice(TEST_DEVICE_ID)
@@ -102,3 +101,8 @@ class AdbServerTest(unittest.TestCase):
   def test_no_available(self):
     device = simpleadb.AdbDevice('dummy_id')
     self.assertFalse(device.is_available())
+  
+  def test_unroot(self):
+    device = simpleadb.AdbDevice(TEST_DEVICE_ID)
+    res = device.unroot()
+    self.assertEqual(res, 0)


### PR DESCRIPTION
adb root/unroot restarting the server, so calling
```
#...
device.root()
device.do_whatever()
#...
```
is race'y `device.do_whatever()` may or may not pass because we don't know if the adb device is accessible

fix:
* wait for device to be accessible after root/unroot
* remove previous workaround #8 
* todo: address this in every adb restart possible scenario

Usage
```Python
device.root()   # default timeout for failure scenario 5s
device.root(15) # big timeout (15 sec) for some extreme cases
```