### PR TITLE
make default adb port configurable

### DIFF
--- a/simpleadb.py
+++ b/simpleadb.py
@@ -1,4 +1,3 @@
-import os
 import adbprocess
 import adbprefixes
 
@@ -191,7 +190,7 @@ class AdbDevice(object):
 
 
 class AdbServer(object):
-  def __init__(self, port = None):
+  def __init__(self, port=None):
     self.start(port)
 
   @staticmethod
@@ -221,7 +220,7 @@ class AdbServer(object):
 
   def start(self, port=None):
     port_arg = ''
-    if not (port is None):
+    if port is not None:
       port_arg += ' '.join(['-P', str(port)])
     cmd = ' '.join([
         port_arg,

--- a/simpleadb.py
+++ b/simpleadb.py
@@ -1,3 +1,4 @@
+import os
 import adbprocess
 import adbprefixes
 
@@ -76,10 +77,6 @@ class AdbDevice(object):
     if res == 0:
       return self.wait_for_device(timeout=timeout_sec)
     return res
-
-  def usb(self):
-    cmd = adbprefixes.get_usb()
-    return self.__check_call(cmd)
 
   def install(self, apk):
     cmd = ' '.join([
@@ -194,8 +191,8 @@ class AdbDevice(object):
 
 
 class AdbServer(object):
-  def __init__(self):
-    pass
+  def __init__(self, port = None):
+    self.start(port)
 
   @staticmethod
   def __check_call(args):
@@ -222,8 +219,23 @@ class AdbServer(object):
         devices.append(AdbDevice(device_id))
     return devices
 
+  def start(self, port=None):
+    port_arg = ''
+    if not (port is None):
+      port_arg += ' '.join(['-P', str(port)])
+    cmd = ' '.join([
+        port_arg,
+        adbprefixes.get_start_server(),
+    ])
+    res = self.__check_call(cmd)
+    return res
+
   def kill(self):
     cmd = adbprefixes.get_kill_server()
+    return self.__check_call(cmd)
+
+  def usb(self):
+    cmd = adbprefixes.get_usb()
     return self.__check_call(cmd)
 
   def tcpip(self, port):

--- a/test_simpleadb.py
+++ b/test_simpleadb.py
@@ -126,3 +126,10 @@ class AdbServerTest(unittest.TestCase):
     device = simpleadb.AdbDevice(TEST_DEVICE_ID)
     res = device.unroot()
     self.assertEqual(res, 0)
+
+  def test_restart_server(self):
+    adb = simpleadb.AdbServer('4242')
+    res = adb.kill()
+    self.assertEqual(res, 0)
+    res = adb.start('1234')
+    self.assertEqual(res, 0)


### PR DESCRIPTION
```Python
>>> import simpleadb
>>> adb = simpleadb.AdbServer('5553') # start adb daemon on port 5553
>>> adb.kill()  # kill adb daemon
>>> adb.start('1234') # start again on port 1234
>>> adb.kill()
>>> adb.start() # start on default port
```