### PR TITLE
add eq operator for AdbDevice

### DIFF
--- a/simpleadb.py
+++ b/simpleadb.py
@@ -27,6 +27,9 @@ class AdbDevice(object):
   def __eq__(self, other):
     return self.get_id() == other.get_id()
 
+  def __ne__(self, other):
+    return not self.__eq__(other)
+
   def __check_call(self, args):
     cmd = ' '.join([
         adbprefixes.get_set_device(self.get_id()),

--- a/simpleadb.py
+++ b/simpleadb.py
@@ -24,6 +24,9 @@ class AdbDevice(object):
   def __init__(self, device_id):
     self.__id = device_id
 
+  def __eq__(self, other):
+    return self.get_id() == other.get_id()
+
   def __check_call(self, args):
     cmd = ' '.join([
         adbprefixes.get_set_device(self.get_id()),

--- a/test_simpleadb.py
+++ b/test_simpleadb.py
@@ -32,6 +32,13 @@ class AdbServerTest(unittest.TestCase):
     emulator = devices[0]
     self.assertTrue(TEST_DEVICE_ID in emulator.get_id())
 
+  def test_device_eq(self):
+    dev1 = simpleadb.AdbDevice('1234')
+    dev2 = simpleadb.AdbDevice('1234')
+    dev3 = simpleadb.AdbDevice('42')
+    self.assertEqual(dev1, dev2)
+    self.assertNotEqual(dev1, dev3)
+
   def test_root(self):
     device = simpleadb.AdbDevice(TEST_DEVICE_ID)
     res = device.root()


### PR DESCRIPTION
Two object with the same id points to the same device so should be equal
```Python
>>> dev1 = simpleadb.AdbDevice('1234')
>>> dev2 = simpleadb.AdbDevice('1234')
>>> dev1 == dev2
True
>>> dev3 = simpleadb.AdbDevice('12345')
>>> dev2 == dev3
False
```

```