### PR TITLE
Add __str__ to AdbDevice

### DIFF
--- a/simpleadb/simpleadb.py
+++ b/simpleadb/simpleadb.py
@@ -24,6 +24,9 @@ class AdbDevice(object):
   def __init__(self, device_id):
     self.__id = device_id
 
+  def __str__(self):
+    return self.get_id()
+
   def __eq__(self, other):
     return self.get_id() == other.get_id()
 

--- a/tests/test_simpleadb.py
+++ b/tests/test_simpleadb.py
@@ -38,6 +38,10 @@ class AdbServerTest(unittest.TestCase):
     self.assertEqual(dev1, dev2)
     self.assertNotEqual(dev1, dev3)
 
+  def test_str(self):
+    device = simpleadb.AdbDevice(TEST_DEVICE_ID)
+    self.assertEqual(TEST_DEVICE_ID, str(device))
+
   def test_root(self):
     device = simpleadb.AdbDevice(TEST_DEVICE_ID)
     res = device.root()


### PR DESCRIPTION
The `AdbDevice` can be printed now
```Python
>>> import simpleadb
>>> device = simpleadb.AdbDevice('1234')
>>> print(device)
1234
```