### PR TITLE
fix print list of devices

### DIFF
--- a/simpleadb/simpleadb.py
+++ b/simpleadb/simpleadb.py
@@ -27,6 +27,9 @@ class AdbDevice(object):
   def __str__(self):
     return self.get_id()
 
+  def __repr__(self):
+    return self.__str__()
+
   def __eq__(self, other):
     return self.get_id() == other.get_id()
 


### PR DESCRIPTION
```Python
>>> import simpleadb
>>> adb = simpleadb.AdbServer()
>>> devices = adb.devices()
>>> devices
# output before
[<simpleadb.simpleadb.AdbDevice object at 0x5032d4453da0>, <simpleadb.simpleadb.AdbDevice object at 0x7f4004582f28>]
# output after
[emulator-5554, emulator-5555]
```