### PR TITLE
Switch to API 27 in test emulator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [29]
+        api-level: [27]
         python-version: ["3.6"]
     steps:
       - name: Checkout


### PR DESCRIPTION
api 27 should be more reliable
https://github.com/ReactiveCircus/android-emulator-runner/issues/55