### PR TITLE
Kill every adb leftover process after tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,9 +69,24 @@ jobs:
           emulator-options: |
               -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: |
-            adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82'
-            coverage run --source=simpleadb -m pytest -v tests
+          script: >
+            adb wait-for-device
+            &&
+            adb shell 'while [ -z "$(getprop sys.boot_completed)" ]; do sleep 1; done'
+            &&
+            adb shell input keyevent 82
+            &&
+            coverage run --source=simpleadb -m pytest -v tests;
+            TEST_EXIT_CODE=$?;
+            echo "=== Starting emulator cleanup ===";
+            adb emu kill || echo "ADB kill failed - proceeding to force kill";
+            pkill -9 -f "emulator" || true;
+            pkill -9 -f "qemu" || true;
+            pkill -9 -f "adb" || true;
+            pkill -9 -f "crashpad_handler" || true;
+            echo "=== Remaining processes ===";
+            ps aux | grep -E 'qemu|emulator' || true;
+            exit $TEST_EXIT_CODE
 
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 [Unreleased](https://github.com/michalkielan/simple-adb/compare/0.5.3...HEAD)
 -----------------------------------------------------------------------------
 
+### Fixed
+- ci unit tests regression
+
 [0.5.3](https://github.com/michalkielan/simple-adb/compare/0.5.2...0.5.3) - 2025-03-24
 --------------------------------------------------------------------------------------
 
 ### Fixed
-- Automatic pkg deployment
+- automatic pkg deployment
 
 ### Changed
 - remove repository section from deployment script


### PR DESCRIPTION
Force kill emulator processes after tests are executed to prevent unit tests stuck